### PR TITLE
Open contribution paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: 问题与视觉反馈 / Bug & visual feedback
+description: 报告可复现的问题，尤其是灯光、阴影、相机或交互异常 / Report reproducible behavior or visual problems
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢反馈。视觉问题请尽量附截图或录屏；中文或英文都可以。
+        Thanks for helping. Screenshots or recordings are especially useful for visual issues. Chinese or English is welcome.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 问题类型 / Area
+      options:
+        - 灯光、阴影或材质 / Lighting, shadows, or materials
+        - 相机、视图或构图 / Camera, views, or framing
+        - 人物、道具或拖动 / People, props, or dragging
+        - 保存、A/B 对比或导出 / Save, A/B compare, or export
+        - 安装、构建或桌面版 / Install, build, or desktop app
+        - 其他 / Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: happened
+    attributes:
+      label: 发生了什么 / What happened?
+      description: 请描述你看到的结果，以及它为什么影响使用。
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 如何复现 / How to reproduce
+      description: 从默认场景开始，列出最短步骤；如有特定灯位、数值或视角也请写明。
+      placeholder: |
+        1. 打开在线 demo
+        2. 选择……
+        3. 调整……
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望结果 / Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: media
+    attributes:
+      label: 截图或录屏 / Screenshots or recording
+      description: 可以直接拖入文件。涉及视觉差异时，最好同时提供当前结果和期望参考。
+
+  - type: input
+    id: environment
+    attributes:
+      label: 使用环境 / Environment
+      description: 例如 Chrome 版本、macOS / Windows、在线 demo 或桌面版。
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 提交前确认 / Before submitting
+      options:
+        - label: 我已搜索现有 Issues，未发现同一问题。 / I searched existing Issues and did not find the same report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 布光方案、问题与早期想法 / Setups, questions, and early ideas
+    url: https://github.com/oukeming64-tech/direct-light/discussions
+    about: 分享布光方案、真实片场工作流，或先讨论还不适合写成 Issue 的想法。

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: 工作流建议 / Workflow idea
+description: 从真实布光或沟通需求出发提出改进 / Propose an improvement grounded in a real workflow
+title: "[Idea] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请先描述问题和使用场景，不必预先设计完整方案。仍需探索的想法也可以先放到 Discussions。
+        Start with the problem and workflow; you do not need to design the full solution. Early ideas can begin in Discussions.
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: 真实场景 / Real workflow
+      description: 谁在什么情况下使用 Direct Light？现在卡在哪里？
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: 希望得到什么结果 / Desired outcome
+      description: 描述完成任务后应该发生什么，而不只是列出一个按钮或功能名。
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: 目前如何处理 / Current workaround
+      description: 如果现在有替代方法，请说明它为什么不够好。
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 截图、示例或参考 / Screenshots, examples, or references
+
+  - type: dropdown
+    id: participation
+    attributes:
+      label: 你愿意如何参与 / How would you like to help?
+      options:
+        - 提供更多使用反馈 / Provide more workflow feedback
+        - 帮助测试 / Help test
+        - 尝试提交代码 / Try a code contribution
+        - 先提出想法 / Idea only for now
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 提交前确认 / Before submitting
+      options:
+        - label: 我已搜索现有 Issues 和 Discussions。 / I searched existing Issues and Discussions.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## 改了什么 / What changed
+
+<!-- 用几句话说明改动。 / Summarize the change in a few sentences. -->
+
+## 为什么 / Why
+
+<!-- 它解决了什么真实问题？关联 Issue 时请写 Closes #...。 -->
+
+## 如何看到结果 / How to verify
+
+<!-- 列出最短复现步骤。涉及视觉或产品行为时，请附截图、录屏或 A/B 对比。 -->
+
+## 检查 / Checks
+
+只勾选适用且实际运行过的项目；未运行请说明原因。
+
+- [ ] `npx tsc -b`
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] 相关文档已同步，或本次改动不需要更新文档
+
+## 范围 / Scope
+
+<!-- 说明刻意没有改什么，避免维护者从 diff 猜测范围。 -->

--- a/COLLABORATION.md
+++ b/COLLABORATION.md
@@ -20,6 +20,13 @@ Released baseline: `v1.0.3`.
 
 ## Latest Documentation Cleanup
 
+2026-07-10 (public contribution paths):
+
+- Changed: added visible Issue / Discussion invitations to both public README front pages, added contribution entry guidance, and clarified that roadmap candidates require scope agreement before implementation.
+- Changed: added structured Issue forms and a concise pull-request template under `.github/`; fixed stale contribution-guide references to the removed README desktop section and archived roadmap numbering.
+- Changed: enabled GitHub Discussions so non-code feedback, lighting setups, and early ideas have a lower-pressure home than Issues.
+- Not changed: application code, runtime behavior, rendering values, product priorities, released version `v1.0.3`, tags, build configuration, or deployment workflows.
+
 2026-06-29:
 
 - Changed: archived completed root specs under `docs/history/specs/`, old Hermes handoff notes under `docs/history/handoffs/`, and full historical snapshots of README / ROADMAP / ARCHITECTURE / RENDERING_SPEC under `docs/history/snapshots/`.
@@ -32,7 +39,7 @@ Released baseline: `v1.0.3`.
 - Changed: rebuilt root `README.md` (73 → 118 lines) back into the public showcase front page — hero GIF, screenshots table, emoji feature list, tech stack, project-structure table, known-limits/tradeoffs, and the Dr. Zhang acknowledgement. The full PRD stays archived; `README.md` links to it instead of inlining it.
 - Changed: rewrote `README.en.md` as a faithful English mirror of the new `README.md` (also 118 lines, identical section structure); added the Documentation-map / history-archive block (incl. the PRD link) that English readers previously lacked, and dropped the standalone Desktop section in favor of the compact `build:tauri` + unsigned-first-launch note, matching the Chinese front page.
 - Not changed: `ROADMAP.md`, `ARCHITECTURE.md`, `RENDERING_SPEC.md` (still short current-entry docs), the archived snapshots under `docs/history/snapshots/`, showcase code, app code, and all release/deploy state.
-- Note (pre-existing follow-up): `CONTRIBUTING.md` still points desktop-build detail at the README "桌面版（macOS）" section, which both front pages now fold into a one-liner; the full steps live in the archived `README_FULL` snapshot. Repoint when convenient.
+- Resolved on 2026-07-10: `CONTRIBUTING.md` no longer points desktop-build detail at the removed README "桌面版（macOS）" section; it now points contributors to the current Releases entry and release workflow.
 
 ## Released Lines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,14 @@
 
 > English summary at the bottom.
 
+## 不写代码也可以参与
+
+- 灯光、阴影、相机或交互看起来不对：通过 [Issue 表单](https://github.com/oukeming64-tech/direct-light/issues/new/choose)提交复现步骤，视觉问题尽量附截图或录屏。
+- 想分享布光方案、真实片场需求，或者想法还需要讨论：到 [Discussions](https://github.com/oukeming64-tech/direct-light/discussions) 开一个话题。
+- 想贡献代码：先查看[开放中的 Issues](https://github.com/oukeming64-tech/direct-light/issues)。较大的功能请先讨论范围；小而明确的 bug 修复可以直接提交 PR。
+
+路线图描述的是值得探索的方向，不代表每个方向都已经决定实现。维护者会优先接收能改善导演沟通效率、并且可以通过可见结果验证的改动。
+
 ## 环境要求
 
 - Node.js **>= 20.19**（推荐 20 LTS 或 22 LTS）
@@ -26,7 +34,7 @@ npm run lint       # eslint .
 npm run preview    # 本地预览已构建的产物
 ```
 
-桌面版（Tauri，可选，需 [Rust](https://www.rust-lang.org/tools/install) 工具链 + Xcode CLT）：`npm run tauri dev` 实时调试、`npm run tauri build` 出 `.app`/`.dmg`。代码在 `src-tauri/`，发版 CI 见 `.github/workflows/release.yml`，细节见 README「桌面版（macOS）」。Rust 依赖由提交的 `src-tauri/Cargo.lock` 锁定以保证构建可复现（避免上游 patch 漂移导致 CI 失败）；需要刷新锁文件时手动运行 Actions 里的「Update Cargo.lock」工作流（`.github/workflows/lockfile.yml`），不要在 `release.yml` 里临时 `cargo generate-lockfile`。
+桌面版（Tauri，可选，需 [Rust](https://www.rust-lang.org/tools/install) 工具链 + Xcode CLT）：`npm run tauri dev` 实时调试、`npm run tauri build` 出 `.app`/`.dmg`。代码在 `src-tauri/`，发版 CI 见 `.github/workflows/release.yml`；当前公开安装包见 README 顶部的 Releases 链接。Rust 依赖由提交的 `src-tauri/Cargo.lock` 锁定以保证构建可复现（避免上游 patch 漂移导致 CI 失败）；需要刷新锁文件时手动运行 Actions 里的「Update Cargo.lock」工作流（`.github/workflows/lockfile.yml`），不要在 `release.yml` 里临时 `cargo generate-lockfile`。
 
 提交前请确保三件事都通过：**`npx tsc -b` · `npm run lint` · `npm run build`**。
 
@@ -56,7 +64,7 @@ npm run preview    # 本地预览已构建的产物
 ## 提交约定
 
 - 一次提交聚焦一件事；信息写清「做了什么 + 为什么」。
-- 涉及产品行为/视觉的改动，请说明如何在 A/B 对比里被看到（参考 `ROADMAP.md §11`）。
+- 涉及产品行为/视觉的改动，请说明如何在截图、录屏或应用内 A/B 对比里看到变化。
 - 改了功能、修了重要 bug 或改变实现方向，请同步更新 [`COLLABORATION.md`](COLLABORATION.md) 的版本记录。
 
 ## 当前已知限制（第一版）
@@ -75,6 +83,8 @@ npm run preview    # 本地预览已构建的产物
 
 Direct Light is a white-studio lighting previz sandbox. To contribute:
 
+- No code required: use the [Issue forms](https://github.com/oukeming64-tech/direct-light/issues/new/choose) for reproducible bugs or visual feedback, and [Discussions](https://github.com/oukeming64-tech/direct-light/discussions) for lighting setups, production workflows, questions, and early ideas.
+- For code contributions, check [open Issues](https://github.com/oukeming64-tech/direct-light/issues). Discuss larger changes before implementation; small, focused bug fixes may go straight to a PR.
 - Requires **Node.js >= 20.19**.
 - `npm install` → `npm run dev` (Vite dev server on `:5173`).
 - Before any PR, make sure **`npx tsc -b`**, **`npm run lint`**, and **`npm run build`** all pass.

--- a/README.en.md
+++ b/README.en.md
@@ -14,6 +14,8 @@
 - 🌐 Live demo: <https://oukeming64-tech.github.io/direct-light/> — no install, works on mobile too, auto-updated on every push to `main`.
 - 🖥️ macOS desktop: the `.dmg` on [Releases](https://github.com/oukeming64-tech/direct-light/releases/latest) (universal Apple Silicon / Intel).
 
+> Found lighting, shadow, or interaction behavior that does not look right? [Report a bug or visual issue](https://github.com/oukeming64-tech/direct-light/issues/new/choose). To share a lighting setup, a real production workflow, or an early idea, start a thread in [Discussions](https://github.com/oukeming64-tech/direct-light/discussions) — no code required.
+
 A frontend-only web app, no backend. It optimizes for **communication, real-time feedback, and readability** — not physically accurate rendering. Unlike heavyweight 3D / paid set-lighting software, it's instant, install-free, and built for talking through a lighting setup with your crew during prep.
 
 ![Direct Light demo: adjust the camera position, then switch to the through-lens view and watch the framing and lighting update live](docs/media/hero.gif)
@@ -94,6 +96,16 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) (Chinese) for full module boundaries, a
 - Custom fixtures live in localStorage only — moving them across devices / sharing is via JSON export / import.
 - Desktop-first; a narrow-mobile responsive layout is scheduled separately.
 - The renderer is a communication-oriented approximation, not a physically accurate simulation: studio reflectance, soft light, colored spill, and gear optics all favor readable, stable, real-time output.
+
+## Contributing
+
+Direct Light welcomes directors, DPs, gaffers, 3D / Web developers, and anyone curious about lighting. You can:
+
+- Reproduce a problem in the live demo, then use an [Issue form](https://github.com/oukeming64-tech/direct-light/issues/new/choose) with steps, screenshots, or a recording.
+- Share lighting setups, real production needs, and early ideas in [Discussions](https://github.com/oukeming64-tech/direct-light/discussions).
+- Browse [open Issues](https://github.com/oukeming64-tech/direct-light/issues), pick work with an agreed scope, and follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for a PR.
+
+Roadmap candidates are not pre-approved features. For larger changes, open an Issue or Discussion first so the problem and scope can be agreed; small, focused bug fixes may go straight to a PR.
 
 ## Documentation map
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 - 🌐 在线 demo：<https://oukeming64-tech.github.io/direct-light/> —— 免安装、手机也能开，随 `main` 自动更新。
 - 🖥️ macOS 桌面版：[Releases](https://github.com/oukeming64-tech/direct-light/releases/latest) 的 `.dmg`（Apple Silicon / Intel 通用）。
 
+> 发现灯光、阴影或交互不符合预期？欢迎[提交问题或视觉反馈](https://github.com/oukeming64-tech/direct-light/issues/new/choose)。有布光方案、片场工作流或还不成熟的想法，也欢迎到 [Discussions](https://github.com/oukeming64-tech/direct-light/discussions) 交流；不需要会写代码。
+
 纯前端 Web 应用，无后端依赖。强调**沟通向、实时、可读**，而不是物理级精确渲染——区别于重型 3D / 付费布光软件，它即开即用、专为前期和团队沟通灯光方案而做。
 
 ![Direct Light 演示：调整摄影机机位后切到「镜头」视角，画面与光影实时变化](docs/media/hero.gif)
@@ -94,6 +96,16 @@ Vite · React 19 · TypeScript · React Three Fiber + drei（Three.js）· Zusta
 - 自定义灯具器械只存本地 localStorage，跨设备 / 分享需用「导出 / 导入」手动搬运。
 - 桌面 / 工作台体验优先；移动端窄屏响应式后续单独排期。
 - 渲染是导演沟通向近似，不是物理准确模拟：白棚反射、柔光、彩色溢光和控光器材光学都以可读、稳定、实时为先。
+
+## 参与项目
+
+Direct Light 欢迎导演、摄影指导、灯光师、3D / Web 开发者以及只是对布光好奇的人参与。你可以：
+
+- 在在线 demo 里复现问题，通过 [Issue 表单](https://github.com/oukeming64-tech/direct-light/issues/new/choose)附上步骤、截图或录屏。
+- 在 [Discussions](https://github.com/oukeming64-tech/direct-light/discussions) 分享布光方案、真实片场需求和仍需讨论的想法。
+- 查看[开放中的 Issues](https://github.com/oukeming64-tech/direct-light/issues)，选择已经说明范围的工作，再按 [`CONTRIBUTING.md`](CONTRIBUTING.md) 提交 PR。
+
+路线图里的候选方向不等于已经决定的功能。较大的改动请先开 Issue 或 Discussion 对齐问题与范围；小而明确的 bug 修复可以直接提交 PR。
 
 ## 文档地图
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,12 +29,14 @@ The most important behavior remains:
 
 ## Next Candidate Work
 
-Not committed until explicitly picked:
+These are invitation areas for real-use feedback and scoped proposals, not pre-approved features:
 
 - More realistic fixture / photometric data.
 - Mobile/narrow-screen workflow improvements for the app.
 - More export/share flows for communicating lighting plans.
 - Continued rendering polish when it fixes a concrete visual regression.
+
+Use [Discussions](https://github.com/oukeming64-tech/direct-light/discussions) to share workflow context or explore an early idea. Use [Issues](https://github.com/oukeming64-tech/direct-light/issues) for reproducible problems and proposals with a concrete scope. A roadmap candidate becomes implementation work only after that scope is agreed.
 
 ## Completed Lines
 
@@ -53,5 +55,7 @@ Do not reopen unless fixing a concrete regression:
 ## Documentation Note
 
 Changed in the 2026-06-29 cleanup: this root roadmap was shortened to current state and next candidates.
+
+Changed on 2026-07-10: candidate work now links to public feedback and contribution entry points, while remaining explicitly uncommitted until scoped.
 
 Not changed: product priorities, released version status, app code, build behavior, and release workflow.


### PR DESCRIPTION
## What changed

- added bilingual Issue forms for reproducible bugs, visual feedback, and workflow ideas
- added a concise pull-request template
- added visible Issue and Discussion invitations to both README front pages
- clarified contribution paths in `CONTRIBUTING.md` and `ROADMAP.md`
- recorded the GitHub Discussions setting and explicit non-scope in `COLLABORATION.md`
- fixed two stale contribution-guide references discovered during doc sync

## Why

Direct Light already has a credible, complete public face, but unfamiliar visitors had no low-pressure path for sharing lighting setups or early ideas and no structured path for reporting visual problems. These changes make participation visible without presenting roadmap candidates as promised features.

GitHub Discussions is now enabled, and the first Show and tell thread is live:
https://github.com/oukeming64-tech/direct-light/discussions/3

## Impact

No application code, runtime behavior, rendering values, release version, build configuration, or deployment workflow changed.

## Validation

- `npx tsc -b`
- `npm run lint`
- `npm run build`
- Issue-form YAML parsed successfully
- `git diff --check`
- current documentation checked for stale roadmap and README-section references
